### PR TITLE
Remove print statement in vector.lua

### DIFF
--- a/lua/lemongate/components/vector.lua
+++ b/lua/lemongate/components/vector.lua
@@ -39,7 +39,6 @@ local %Current = %memory[value %1] or Vector3.Zero:Clone()
 %delta[ value %1] = %Current
 if !%trigger[value %1] then 
 	%trigger[value %1] = %Current.x ~= value %2.x or %Current.y ~= value %2.y or %Current.z ~= value %2.z
-	print( "Checker:", value %1, %trigger[value %1] )
 end
 ]], "value %2" )
 


### PR DESCRIPTION
This print statement will print in console thousands of times, causing the log files to be enormous. It is a real pain to deal with.
